### PR TITLE
Fix for macOS 13.3 memory allocation regression

### DIFF
--- a/AudioAnalyzer/DFT.swift
+++ b/AudioAnalyzer/DFT.swift
@@ -35,7 +35,7 @@ final class DFT {
                 defer {
                     // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
                     // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
-                    free(audioBufferList.unsafeMutablePointer)
+//                    free(audioBufferList.unsafeMutablePointer)
                 }
                 guard let asbd = sampleBuffer.formatDescription?.audioStreamBasicDescription else { return }
                 let samplesCount = min(Int(sampleBuffer.numSamples), bufferLength)

--- a/AudioAnalyzer/DFT.swift
+++ b/AudioAnalyzer/DFT.swift
@@ -33,9 +33,13 @@ final class DFT {
 
             try sampleBuffer.withAudioBufferList { audioBufferList, blockBuffer in
                 defer {
-                    // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
-                    // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
-//                    free(audioBufferList.unsafeMutablePointer)
+                    if #available(macOS 13.3, *) {
+                        // macOS 13.3 no longer needs free() workaround
+                    } else {
+                        // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
+                        // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
+                        free(audioBufferList.unsafeMutablePointer)
+                    }
                 }
                 guard let asbd = sampleBuffer.formatDescription?.audioStreamBasicDescription else { return }
                 let samplesCount = min(Int(sampleBuffer.numSamples), bufferLength)

--- a/AudioAnalyzer/ScreenCaptureKit/ScreenCaptureKitCaptureSession.swift
+++ b/AudioAnalyzer/ScreenCaptureKit/ScreenCaptureKitCaptureSession.swift
@@ -49,9 +49,13 @@ final class ScreenCaptureKitCaptureSession: NSObject, SCStreamOutput, SessionTyp
                 do {
                     try current.buffer.withAudioBufferList { audioBufferList, blockBuffer in
                         defer {
-                            // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
-                            // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
-//                            free(audioBufferList.unsafeMutablePointer)
+                            if #available(macOS 13.3, *) {
+                                // macOS 13.3 no longer needs free() workaround
+                            } else {
+                                // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
+                                // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
+                                free(audioBufferList.unsafeMutablePointer)
+                            }
                         }
                         let samplesCount = current.buffer.numSamples
 

--- a/AudioAnalyzer/ScreenCaptureKit/ScreenCaptureKitCaptureSession.swift
+++ b/AudioAnalyzer/ScreenCaptureKit/ScreenCaptureKitCaptureSession.swift
@@ -51,7 +51,7 @@ final class ScreenCaptureKitCaptureSession: NSObject, SCStreamOutput, SessionTyp
                         defer {
                             // audioBufferList requires free. refs https://daisuke-t-jp.hatenablog.com/entry/2019/10/15/AVCaptureSession
                             // observed as swift_slowAlloc in Malloc 32 Bytes on Instruments
-                            free(audioBufferList.unsafeMutablePointer)
+//                            free(audioBufferList.unsafeMutablePointer)
                         }
                         let samplesCount = current.buffer.numSamples
 


### PR DESCRIPTION
On macOS 13.3 Ventura the API does free the pointer returned from `withAudioBufferList`. It means app developers should not free it for the system.

```
AudioAnalyzer (6759 0x16f707000) malloc: *** error for object 0x600000771110:
pointer being freed was not allocated
```

![image](https://user-images.githubusercontent.com/11156/230756172-68be1f81-e0b4-4c55-bbec-4f055cfb2875.png)
